### PR TITLE
Changed icon colors to blue

### DIFF
--- a/src/lib/components/map/layers/LocationDialog.svelte
+++ b/src/lib/components/map/layers/LocationDialog.svelte
@@ -38,17 +38,17 @@
 						{#if layerName.startsWith('Aves')}
 							<Fa icon={faCrow} color="blue" size="2x" />
 						{:else if layerName.startsWith('A ‘AMU')}
-							<Fa icon={faBookOpen} color="black" size="2x" />
+							<Fa icon={faBookOpen} color="blue" size="2x" />
 						{:else if layerName.startsWith('Koro')}
-							<Fa icon={faLightbulb} color="#0872C9" size="2x" />
+							<Fa icon={faLightbulb} color="blue" size="2x" />
 						{:else if layerName.startsWith('Hist')}
-							<Fa icon={faCirclePlay} color="green" size="2x" />
+							<Fa icon={faCirclePlay} color="blue" size="2x" />
 						{:else if layerName.startsWith('Agro')}
-							<Fa icon={faLeaf} color="#15803d" size="2x" />
+							<Fa icon={faLeaf} color="blue" size="2x" />
 						{:else if layerName.startsWith('Macro')}
-							<Fa icon={faBook} color="purple" size="2x" />
+							<Fa icon={faBook} color="blue" size="2x" />
 						{:else}
-							<Fa icon={faMapMarkerAlt} color="white" size="2x" />
+							<Fa icon={faMapMarkerAlt} color="blue" size="2x" />
 						{/if}
 					</span>
 				</Tooltip.Trigger>

--- a/src/lib/components/map/sidebars/toggles/LayerToggler.svelte
+++ b/src/lib/components/map/sidebars/toggles/LayerToggler.svelte
@@ -49,17 +49,17 @@
 				{#if layer.name.startsWith('Aves')}
 					<Fa icon={faCrow} color="blue" />
 				{:else if layer.name.startsWith('A ‘AMU')}
-					<Fa icon={faBookOpen} color="black" />
+					<Fa icon={faBookOpen} color="blue" />
 				{:else if layer.name.startsWith('Koro')}
-					<Fa icon={faLightbulb} color="#0872C9" />
+					<Fa icon={faLightbulb} color="blue" />
 				{:else if layer.name.startsWith('Hist')}
-					<Fa icon={faCirclePlay} color="green" />
+					<Fa icon={faCirclePlay} color="blue" />
 				{:else if layer.name.startsWith('Agro')}
-					<Fa icon={faLeaf} color="#15803d" />
+					<Fa icon={faLeaf} color="blue" />
 				{:else if layer.name.startsWith('Macro')}
-					<Fa icon={faBook} color="purple" />
+					<Fa icon={faBook} color="blue" />
 				{:else}
-					<Fa icon={faMapMarkerAlt} color="white" />
+					<Fa icon={faMapMarkerAlt} color="blue" />
 				{/if}
 			</div>
 		</div>


### PR DESCRIPTION
This PR changes the layer icons to be blue rather than distinct colors. The purpose of this is to avoid accessibility issues with colorblind users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated icon colors in map interface for visual consistency. Icons across location dialogs and layer toggles now display in a unified blue color scheme for improved visual coherence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->