### PR TITLE
Nico/minor macrocuentos changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Migration scripts (contain credentials)
+migrate-record.sh

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,3 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
-# Migration scripts (contain credentials)
-migrate-record.sh

--- a/src/lib/components/map/layers/LocationDialog.svelte
+++ b/src/lib/components/map/layers/LocationDialog.svelte
@@ -47,7 +47,7 @@
 							<Fa icon={faCirclePlay} color="blue" size="2x" />
 						{:else if layerName.startsWith('Agro')}
 							<Fa icon={faLeaf} color="blue" size="2x" />
-						{:else if layerName.startsWith('Macro')}
+						{:else if layerName.startsWith('Macro') || layerName.startsWith('\u02BCA\u02BCAMU')}
 							<Fa icon={faBook} color="blue" size="2x" />
 						{:else if layerName.startsWith('Cuentos')}
 							<Fa icon={faFish} color="blue" size="2x" />
@@ -80,7 +80,7 @@
 					<HistPerdidasLayer {location} />
 				{:else if layerName.startsWith('Agro')}
 					<AgroecologyPopup {location} />
-				{:else if layerName.startsWith('Macro')}
+				{:else if layerName.startsWith('Macro') || layerName.startsWith('\u02BCA\u02BCAMU')}
 					<MacroCuentosLayer {location} />
 				{:else if layerName.startsWith('Cuentos')}
 					<CuentosDelMarLayer {location} />

--- a/src/lib/components/map/layers/MacroCuentosInfoDialog.svelte
+++ b/src/lib/components/map/layers/MacroCuentosInfoDialog.svelte
@@ -37,7 +37,7 @@
 		<!-- Header -->
 		<div class="flex flex-col items-center gap-3 px-8 pb-4 pt-8">
 			<Dialog.Title class="text-center text-2xl font-bold tracking-wide md:text-3xl">
-				{showSpanish ? 'Relatos de la Isla de Pascua' : 'Aʼamu o Rapa Nui'}
+				{showSpanish ? 'Relatos de la Isla de Pascua' : 'ʼAʼAMU O RAPA NUI'}
 			</Dialog.Title>
 
 			<!-- Language toggle -->

--- a/src/lib/components/map/layers/MacroCuentosLayer.svelte
+++ b/src/lib/components/map/layers/MacroCuentosLayer.svelte
@@ -50,7 +50,7 @@
 			class="flex flex-col items-center gap-6 text-center"
 			style="font-family: 'Merriweather', serif;"
 		>
-			<div class="mx-auto flex w-full max-w-2xl flex-col items-center gap-3 px-6">
+			<div class="mx-auto flex w-full max-w-[60%] flex-col items-center gap-3 px-6">
 				<h1 class="text-3xl font-bold">{author.name}</h1>
 
 				{#if hasBioSpanish}
@@ -142,7 +142,7 @@
 				{author.name}
 			</h2>
 
-			<div class="mx-auto w-full max-w-2xl px-6">
+			<div class="mx-auto w-full max-w-[60%] px-6">
 				<p class="mt-2 whitespace-pre-line text-justify text-lg leading-relaxed">
 					{showSpanish && hasStorySpanish ? selectedStory.text_spanish : selectedStory.text_rapanui}
 				</p>

--- a/src/lib/components/map/layers/MacroCuentosLayer.svelte
+++ b/src/lib/components/map/layers/MacroCuentosLayer.svelte
@@ -17,22 +17,8 @@
 	const selectedStory = $derived(selectedStoryIdx !== null ? stories[selectedStoryIdx] : null);
 	const hasStorySpanish = $derived(Boolean(selectedStory?.text_spanish?.trim()));
 
-	// Split stories into chunks of 4 for multiple cycles
-	const storyCycles = $derived.by(() => {
-		const cycles: (typeof stories)[] = [];
-		for (let i = 0; i < stories.length; i += 4) {
-			cycles.push(stories.slice(i, i + 4));
-		}
-		return cycles;
-	});
-
-	// Same circular positioning as KoronuiLayer
-	const posClasses = [
-		'left-1/2 top-0 -translate-x-1/2 -translate-y-1/2',
-		'right-0 top-1/2 translate-x-1/2 -translate-y-1/2',
-		'left-1/2 bottom-0 -translate-x-1/2 translate-y-1/2',
-		'left-0 top-1/2 -translate-x-1/2 -translate-y-1/2'
-	];
+	const storyTitle = (story: (typeof stories)[number]) =>
+		showSpanish && story.title_spanish?.trim() ? story.title_spanish : story.title;
 
 	function selectStory(index: number) {
 		selectedStoryIdx = index;
@@ -75,26 +61,18 @@
 						</p>
 					</div>
 				{/if}
-			</div>
 
-			<!-- Story cycle selector(s) -->
-			<div class="mb-20 mt-24 flex flex-wrap items-center justify-center gap-0">
-				{#each storyCycles as cycle, cycleIdx}
-					<div class={`relative ${storyCycles.length > 1 ? 'mx-16 my-10 h-28 w-56' : 'h-40 w-80'}`}>
-						<div class="absolute inset-0 rounded-full border-2 border-amber-500 opacity-30"></div>
-
-						{#each cycle as story, i (story.id)}
-							<button
-								class={`absolute ${posClasses[i % posClasses.length]}
-									${storyCycles.length > 1 ? 'max-w-[7rem] px-3 py-2 text-xs' : 'max-w-[10rem] px-5 py-3 text-sm'}
-									rounded-full bg-amber-700 text-center leading-tight text-white shadow-lg hover:bg-amber-800`}
-								onclick={() => selectStory(cycleIdx * 4 + i)}
-							>
-								{showSpanish && story.title_spanish?.trim() ? story.title_spanish : story.title}
-							</button>
-						{/each}
-					</div>
-				{/each}
+				<!-- Story selector grid -->
+				<div class="mt-6 flex w-full flex-wrap justify-center gap-4">
+					{#each stories as story, i (story.id)}
+						<button
+							class="rounded-xl border-2 border-amber-500/30 bg-amber-700 px-4 py-3 text-sm leading-snug text-white shadow-md transition-all hover:scale-105 hover:bg-amber-800 hover:shadow-lg"
+							onclick={() => selectStory(i)}
+						>
+							{storyTitle(story)}
+						</button>
+					{/each}
+				</div>
 			</div>
 		</div>
 	{:else if selectedStory}

--- a/src/lib/components/map/sidebars/toggles/LayerToggler.svelte
+++ b/src/lib/components/map/sidebars/toggles/LayerToggler.svelte
@@ -24,7 +24,7 @@
 	const toggleLayer = (layer: ExpandedLayer) => {
 		const isSelecting = selectedLayerId !== layer.id;
 		selectedLayerId = isSelecting ? layer.id : null;
-		if (isSelecting && layer.name.startsWith('Macro')) {
+		if (isSelecting && (layer.name.startsWith('Macro') || layer.name.startsWith('ʼAʼAMU'))) {
 			showMacroInfo = true;
 		}
 	};
@@ -65,7 +65,7 @@
 					<Fa icon={faCirclePlay} color="blue" />
 				{:else if layer.name.startsWith('Agro')}
 					<Fa icon={faLeaf} color="blue" />
-				{:else if layer.name.startsWith('Macro')}
+				{:else if layer.name.startsWith('Macro') || layer.name.startsWith('ʼAʼAMU')}
 					<div class="flex items-center gap-2">
 						{#if selectedLayerId === layer.id}
 							<button


### PR DESCRIPTION
Increased story text width to about 60% of window.

Made basic changes so that the layer can have the name changed to ʼAʼAMU O RAPA NUI (will do on prod once PR accepted). I made it so the layer can be named Macrocuentos or ʼAʼAMU O RAPA NUI just for ease of transition and no downtime

Made the pins be in a circle to match microcuentos on prod

Made the stories displayed in single buttons instead of cycles to be more space effecient and for a cleaner look

<img width="1071" height="737" alt="image" src="https://github.com/user-attachments/assets/4233f896-e8f7-4d9c-9427-20beb81d6467" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended layer support with new layer type and corresponding UI controls

* **Improvements**
  * Redesigned story selection interface from paginated groups to a flat grid for streamlined access to all stories

* **Bug Fixes**
  * Corrected text formatting for Rapa Nui language variant in dialog display

* **Chores**
  * Updated configuration to exclude credential-containing files from version control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->