### PR TITLE
feat: add Historias Perdidas cycle selector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,10 @@ Fetched: 2026-04-25
 
 ## Git And PR Hygiene
 
+- Branch names should follow `name/short-feature`, for example `max/historias-perdidas-cycles`.
 - Keep changes scoped. Avoid mixing feature work, formatting sweeps, dependency updates, and generated type changes unless they are directly related.
 - Do not rewrite student or teammate changes unless explicitly asked. Work with the current branch state.
-- Prefer small commits with clear messages. Use conventional commit style when practical.
+- Prefer small commits with clear messages. Use Conventional Commits when practical, for example `feat: add historias perdidas cycle selector`.
 - Mention known warnings, skipped checks, schema assumptions, and PocketBase data dependencies in the PR notes.
 
 ## Verification

--- a/src/lib/components/map/Map.svelte
+++ b/src/lib/components/map/Map.svelte
@@ -14,6 +14,11 @@
 	import { watchMediaQuery } from '$lib/utils/media-query';
 	import MobileMap from './MobileMap.svelte';
 	import { PUBLIC_POCKETBASE_URL } from '$env/static/public';
+	import {
+		getHistoriasCycle,
+		type HistoriasCycle,
+		isHistoriasPerdidasLayer
+	} from '$lib/historias-perdidas';
 
 	let dark = $state(false);
 	mode.subscribe((m) => {
@@ -27,10 +32,28 @@
 	}: { layers: ExpandedLayer[]; bases: string[]; pruebas: PruebasResponse[] } = $props();
 
 	let selectedLayerId = $state<string | null>(null);
+	let selectedHistoriasCycle = $state<HistoriasCycle>('primer');
 	let selectedBase = $state(bases[0]);
 	let calibrate = false;
 	let isMobile = $state(false);
 	const artisticMapSrc = `${PUBLIC_POCKETBASE_URL}/files/ia77ailu3ghoodv/6jjx168s5ezt2m8/map_k7mm569qll.png`;
+	const visibleLayers = $derived(
+		layers.map((layer) => {
+			if (!isHistoriasPerdidasLayer(layer) || !layer.expand?.locations) {
+				return layer;
+			}
+
+			return {
+				...layer,
+				expand: {
+					...layer.expand,
+					locations: layer.expand.locations.filter(
+						(location) => getHistoriasCycle(location) === selectedHistoriasCycle
+					)
+				}
+			};
+		})
+	);
 
 	onMount(() => {
 		return watchMediaQuery('(max-width: 768px)', (matches) => {
@@ -76,7 +99,7 @@
 					]}
 				>
 					{#if selectedLayerId}
-						{@const selectedLayer = layers.find((l) => l.id === selectedLayerId)}
+						{@const selectedLayer = visibleLayers.find((l) => l.id === selectedLayerId)}
 						{#if selectedLayer}
 							<MarkerPopup layers={[selectedLayer]} {pruebas} />
 						{/if}
@@ -86,7 +109,12 @@
 				{#if calibrate}
 					<CalibrationTool />
 				{:else}
-					<ArtisticBaseMap imageSrc={artisticMapSrc} {layers} {selectedLayerId} {pruebas} />
+					<ArtisticBaseMap
+						imageSrc={artisticMapSrc}
+						layers={visibleLayers}
+						{selectedLayerId}
+						{pruebas}
+					/>
 				{/if}
 			{/if}
 		</div>
@@ -96,13 +124,19 @@
 			bind:rightVisible={rightSidebarVisible}
 		/>
 		<!-- Left Sidebar - Left Layers -->
-		<LeftSidebar {layers} bind:selectedLayerId visible={leftSidebarVisible} />
+		<LeftSidebar
+			{layers}
+			bind:selectedLayerId
+			bind:selectedHistoriasCycle
+			visible={leftSidebarVisible}
+		/>
 		<!-- Right Sidebar - Map Style & Layers -->
 		<RightSidebar
 			{bases}
 			{layers}
 			bind:selectedBase
 			bind:selectedLayerId
+			bind:selectedHistoriasCycle
 			visible={rightSidebarVisible}
 		/>
 	</div>

--- a/src/lib/components/map/sidebars/LeftSidebar.svelte
+++ b/src/lib/components/map/sidebars/LeftSidebar.svelte
@@ -1,7 +1,21 @@
 <script lang="ts">
 	import LayerToggler from './toggles/LayerToggler.svelte';
+	import type { HistoriasCycle } from '$lib/historias-perdidas';
+	import type { ExpandedLayer } from '$lib/expanded-models';
 
-	let { layers = [], selectedLayerId = $bindable(), visible = true } = $props();
+	type Props = {
+		layers?: ExpandedLayer[];
+		selectedLayerId?: string | null;
+		selectedHistoriasCycle?: HistoriasCycle;
+		visible?: boolean;
+	};
+
+	let {
+		layers = [],
+		selectedLayerId = $bindable(),
+		selectedHistoriasCycle = $bindable<HistoriasCycle>('primer'),
+		visible = true
+	}: Props = $props();
 
 	const leftLayers = $derived(layers.filter((layer) => !layer.isRight));
 </script>
@@ -13,7 +27,7 @@
 >
 	<div class="p-6">
 		<div class="space-y-2">
-			<LayerToggler layers={leftLayers} bind:selectedLayerId />
+			<LayerToggler layers={leftLayers} bind:selectedLayerId bind:selectedHistoriasCycle />
 		</div>
 	</div>
 </div>

--- a/src/lib/components/map/sidebars/RightSidebar.svelte
+++ b/src/lib/components/map/sidebars/RightSidebar.svelte
@@ -1,14 +1,26 @@
 <script lang="ts">
 	import BaseToggler from './toggles/BaseToggler.svelte';
 	import LayerToggler from './toggles/LayerToggler.svelte';
+	import type { HistoriasCycle } from '$lib/historias-perdidas';
+	import type { ExpandedLayer } from '$lib/expanded-models';
+
+	type Props = {
+		selectedBase?: string;
+		bases?: string[];
+		layers?: ExpandedLayer[];
+		selectedLayerId?: string | null;
+		selectedHistoriasCycle?: HistoriasCycle;
+		visible?: boolean;
+	};
 
 	let {
 		selectedBase = $bindable(),
 		bases = [],
 		layers = [],
 		selectedLayerId = $bindable(),
+		selectedHistoriasCycle = $bindable<HistoriasCycle>('primer'),
 		visible = true
-	} = $props();
+	}: Props = $props();
 
 	const rightLayers = $derived(layers.filter((layer) => layer.isRight));
 </script>
@@ -23,7 +35,7 @@
 			<BaseToggler {bases} bind:selectedBase />
 		</div>
 		<div class="space-y-2">
-			<LayerToggler layers={rightLayers} bind:selectedLayerId />
+			<LayerToggler layers={rightLayers} bind:selectedLayerId bind:selectedHistoriasCycle />
 		</div>
 		<div class="group relative mt-4 overflow-hidden rounded-lg px-6 py-1">
 			<div

--- a/src/lib/components/map/sidebars/toggles/LayerToggler.svelte
+++ b/src/lib/components/map/sidebars/toggles/LayerToggler.svelte
@@ -14,11 +14,21 @@
 	import { PUBLIC_POCKETBASE_URL } from '$env/static/public';
 	import MacroCuentosInfoDialog from '$lib/components/map/layers/MacroCuentosInfoDialog.svelte';
 	import AgroecologyKey from '$lib/components/map/layers/AgroecologyKey.svelte';
+	import {
+		HISTORIAS_CYCLES,
+		type HistoriasCycle,
+		isHistoriasPerdidasLayer
+	} from '$lib/historias-perdidas';
 
 	let {
 		layers,
-		selectedLayerId = $bindable()
-	}: { layers: ExpandedLayer[]; selectedLayerId?: string | null } = $props();
+		selectedLayerId = $bindable(),
+		selectedHistoriasCycle = $bindable<HistoriasCycle>('primer')
+	}: {
+		layers: ExpandedLayer[];
+		selectedLayerId?: string | null;
+		selectedHistoriasCycle?: HistoriasCycle;
+	} = $props();
 
 	let showMacroInfo = $state(false);
 	let showAgroKey = $state(false);
@@ -45,6 +55,11 @@
 		selectedLayerId = isSelecting ? layer.id : null;
 		if (!isSelecting) return;
 
+		if (isHistoriasPerdidasLayer(layer)) {
+			selectedHistoriasCycle = 'primer';
+			return;
+		}
+
 		if (isAgroecologyLayer(layer) && !hasAutoOpenedAgroKey) {
 			openAgroKey();
 			hasAutoOpenedAgroKey = true;
@@ -53,94 +68,140 @@
 			hasAutoOpenedMacroInfo = true;
 		}
 	};
+
+	const selectHistoriasCycle = (layer: ExpandedLayer, cycle: HistoriasCycle) => {
+		selectedLayerId = layer.id;
+		selectedHistoriasCycle = cycle;
+	};
 </script>
 
 <MacroCuentosInfoDialog bind:open={showMacroInfo} />
 <AgroecologyKey bind:open={showAgroKey} />
 
 {#each layers as layer}
-	<div
-		role="button"
-		tabindex="0"
-		onclick={() => toggleLayer(layer)}
-		onkeydown={(e) => e.key === 'Enter' && toggleLayer(layer)}
-		class="group relative cursor-pointer overflow-hidden rounded-lg px-6 py-1"
-	>
-		<!-- Color flow selection bar -->
-		<div
-			class={`absolute left-0 top-0 h-full w-1.5 bg-orange-600 transition-transform duration-300 ease-out ${
-				selectedLayerId === layer.id ? 'scale-y-100' : 'scale-y-0 group-hover:scale-y-100'
-			}`}
-		></div>
+	{#if isHistoriasPerdidasLayer(layer) && selectedLayerId === layer.id}
+		<div class="relative overflow-hidden rounded-lg px-6 py-1">
+			<div class="absolute left-0 top-0 h-full w-1.5 bg-orange-600"></div>
 
-		<!-- Layer name and icon -->
-		<div class="flex items-center justify-between">
-			<span
-				class="mb-1 text-lg font-medium text-amber-900 transition-colors duration-200 group-hover:text-orange-600"
-			>
-				{layer.name}
-			</span>
-			<div>
-				{#if layer.name.startsWith('Aves')}
-					<Fa icon={faCrow} color="blue" />
-				{:else if layer.name.startsWith('A ‘AMU')}
-					<Fa icon={faBookOpen} color="blue" />
-				{:else if layer.name.startsWith('Koro')}
-					<Fa icon={faLightbulb} color="blue" />
-				{:else if layer.name.startsWith('Hist')}
+			<button type="button" onclick={() => (selectedLayerId = null)} class="group w-full text-left">
+				<div class="flex items-center justify-between">
+					<span
+						class="mb-1 text-lg font-medium text-amber-900 transition-colors duration-200 group-hover:text-orange-600"
+					>
+						{layer.name}
+					</span>
 					<Fa icon={faCirclePlay} color="blue" />
-				{:else if isAgroecologyLayer(layer)}
-					<div class="flex items-center gap-2">
-						{#if selectedLayerId === layer.id}
-							<button
-								onclick={openAgroKey}
-								class="text-amber-600 transition-colors hover:text-orange-600"
-								title="Clave"
-							>
-								<Fa icon={faCircleInfo} size="lg" />
-							</button>
-						{/if}
-						<Fa icon={faLeaf} color="blue" />
-					</div>
-				{:else if isMacroCuentosLayer(layer)}
-					<div class="flex items-center gap-2">
-						{#if selectedLayerId === layer.id}
-							<button
-								onclick={openMacroInfo}
-								class="text-amber-600 transition-colors hover:text-orange-600"
-								title="Sobre el libro"
-							>
-								<Fa icon={faCircleInfo} size="lg" />
-							</button>
-						{/if}
-						<Fa icon={faBook} color="blue" />
-					</div>
-				{:else}
-					<Fa icon={faMapMarkerAlt} color="blue" />
-				{/if}
+				</div>
+			</button>
+
+			{#if layer.description}
+				<p class="text-xs leading-relaxed text-amber-900 opacity-80">
+					{layer.description}
+				</p>
+			{/if}
+
+			<div
+				class="relative my-2 flex aspect-[16/10] flex-col justify-center gap-2 rounded bg-white p-3"
+			>
+				{#each HISTORIAS_CYCLES as cycle}
+					<button
+						type="button"
+						onclick={() => selectHistoriasCycle(layer, cycle.value)}
+						class={`w-full rounded-md px-3 py-2 text-left text-sm transition-colors ${
+							selectedHistoriasCycle === cycle.value
+								? 'bg-orange-100 font-semibold text-orange-700'
+								: 'text-amber-900 hover:bg-amber-100 hover:text-orange-600'
+						}`}
+					>
+						{cycle.label}
+					</button>
+				{/each}
 			</div>
 		</div>
+	{:else}
+		<div
+			role="button"
+			tabindex="0"
+			onclick={() => toggleLayer(layer)}
+			onkeydown={(e) => e.key === 'Enter' && toggleLayer(layer)}
+			class="group relative cursor-pointer overflow-hidden rounded-lg px-6 py-1"
+		>
+			<!-- Color flow selection bar -->
+			<div
+				class={`absolute left-0 top-0 h-full w-1.5 bg-orange-600 transition-transform duration-300 ease-out ${
+					selectedLayerId === layer.id ? 'scale-y-100' : 'scale-y-0 group-hover:scale-y-100'
+				}`}
+			></div>
 
-		<!-- Description -->
-		{#if layer.description}
-			<p class="text-xs leading-relaxed text-amber-900 opacity-80">
-				{layer.description}
-			</p>
-		{/if}
-
-		<!-- Cover photo -->
-		{#if layer.cover_photo && layer.cover_photo.length > 0}
-			<div class="relative my-2 aspect-[16/10] overflow-hidden rounded bg-white">
-				<img
-					src={`${PUBLIC_POCKETBASE_URL}/files/layers/${layer.id}/${layer.cover_photo[0]}`}
-					alt={`Cover photo for ${layer.name}`}
-					class={`h-full w-full object-contain transition-transform duration-300 ease-in-out group-hover:scale-105 ${
-						selectedLayerId === layer.id
-							? 'ring-2 ring-orange-500 ring-offset-2 ring-offset-amber-50'
-							: ''
-					}`}
-				/>
+			<!-- Layer name and icon -->
+			<div class="flex items-center justify-between">
+				<span
+					class="mb-1 text-lg font-medium text-amber-900 transition-colors duration-200 group-hover:text-orange-600"
+				>
+					{layer.name}
+				</span>
+				<div>
+					{#if layer.name.startsWith('Aves')}
+						<Fa icon={faCrow} color="blue" />
+					{:else if layer.name.startsWith('A ‘AMU')}
+						<Fa icon={faBookOpen} color="blue" />
+					{:else if layer.name.startsWith('Koro')}
+						<Fa icon={faLightbulb} color="blue" />
+					{:else if layer.name.startsWith('Hist')}
+						<Fa icon={faCirclePlay} color="blue" />
+					{:else if isAgroecologyLayer(layer)}
+						<div class="flex items-center gap-2">
+							{#if selectedLayerId === layer.id}
+								<button
+									onclick={openAgroKey}
+									class="text-amber-600 transition-colors hover:text-orange-600"
+									title="Clave"
+								>
+									<Fa icon={faCircleInfo} size="lg" />
+								</button>
+							{/if}
+							<Fa icon={faLeaf} color="blue" />
+						</div>
+					{:else if isMacroCuentosLayer(layer)}
+						<div class="flex items-center gap-2">
+							{#if selectedLayerId === layer.id}
+								<button
+									onclick={openMacroInfo}
+									class="text-amber-600 transition-colors hover:text-orange-600"
+									title="Sobre el libro"
+								>
+									<Fa icon={faCircleInfo} size="lg" />
+								</button>
+							{/if}
+							<Fa icon={faBook} color="blue" />
+						</div>
+					{:else}
+						<Fa icon={faMapMarkerAlt} color="blue" />
+					{/if}
+				</div>
 			</div>
-		{/if}
-	</div>
+
+			<!-- Description -->
+			{#if layer.description}
+				<p class="text-xs leading-relaxed text-amber-900 opacity-80">
+					{layer.description}
+				</p>
+			{/if}
+
+			<!-- Cover photo -->
+			{#if layer.cover_photo && layer.cover_photo.length > 0}
+				<div class="relative my-2 aspect-[16/10] overflow-hidden rounded bg-white">
+					<img
+						src={`${PUBLIC_POCKETBASE_URL}/files/layers/${layer.id}/${layer.cover_photo[0]}`}
+						alt={`Cover photo for ${layer.name}`}
+						class={`h-full w-full object-contain transition-transform duration-300 ease-in-out group-hover:scale-105 ${
+							selectedLayerId === layer.id
+								? 'ring-2 ring-orange-500 ring-offset-2 ring-offset-amber-50'
+								: ''
+						}`}
+					/>
+				</div>
+			{/if}
+		</div>
+	{/if}
 {/each}

--- a/src/lib/historias-perdidas.ts
+++ b/src/lib/historias-perdidas.ts
@@ -1,0 +1,23 @@
+import type { ExpandedLayer, ExpandedLocation } from '$lib/expanded-models';
+
+export const HISTORIAS_PERDIDAS_LAYER_ID = '4c4nr8x4kddb839';
+
+export const HISTORIAS_CYCLES = [
+	{ value: 'primer', label: 'Primer Ciclo' },
+	{ value: 'segundo', label: 'Segundo Ciclo' },
+	{ value: 'tercer', label: 'Tercer Ciclo' }
+] as const;
+
+export type HistoriasCycle = (typeof HISTORIAS_CYCLES)[number]['value'];
+
+export function isHistoriasPerdidasLayer(layer: Pick<ExpandedLayer, 'id' | 'name'>): boolean {
+	return layer.id === HISTORIAS_PERDIDAS_LAYER_ID || layer.name === 'Historias Perdidas';
+}
+
+export function getHistoriasCycle(location: ExpandedLocation): HistoriasCycle {
+	return location.hist_cycle ?? 'primer';
+}
+
+export function getHistoriasCycleLabel(cycle: HistoriasCycle): string {
+	return HISTORIAS_CYCLES.find((item) => item.value === cycle)?.label ?? 'Primer Ciclo';
+}

--- a/src/lib/historias-perdidas.ts
+++ b/src/lib/historias-perdidas.ts
@@ -1,4 +1,5 @@
 import type { ExpandedLayer, ExpandedLocation } from '$lib/expanded-models';
+import type { LocationsHistCycleOptions } from '$lib/pocketbase-types';
 
 export const HISTORIAS_PERDIDAS_LAYER_ID = '4c4nr8x4kddb839';
 
@@ -6,9 +7,9 @@ export const HISTORIAS_CYCLES = [
 	{ value: 'primer', label: 'Primer Ciclo' },
 	{ value: 'segundo', label: 'Segundo Ciclo' },
 	{ value: 'tercer', label: 'Tercer Ciclo' }
-] as const;
+] as const satisfies readonly { value: LocationsHistCycleOptions; label: string }[];
 
-export type HistoriasCycle = (typeof HISTORIAS_CYCLES)[number]['value'];
+export type HistoriasCycle = LocationsHistCycleOptions;
 
 export function isHistoriasPerdidasLayer(layer: Pick<ExpandedLayer, 'id' | 'name'>): boolean {
 	return layer.id === HISTORIAS_PERDIDAS_LAYER_ID || layer.name === 'Historias Perdidas';

--- a/src/lib/pocketbase-types.ts
+++ b/src/lib/pocketbase-types.ts
@@ -214,6 +214,14 @@ export const LocationsLanguageOptions = {
 export type LocationsLanguageOptions =
 	(typeof LocationsLanguageOptions)[keyof typeof LocationsLanguageOptions];
 
+export const LocationsHistCycleOptions = {
+	primer: 'primer',
+	segundo: 'segundo',
+	tercer: 'tercer'
+} as const;
+export type LocationsHistCycleOptions =
+	(typeof LocationsHistCycleOptions)[keyof typeof LocationsHistCycleOptions];
+
 export const LocationsTypeOptions = {
 	site: 'site'
 } as const;
@@ -225,6 +233,8 @@ export type LocationsRecord = {
 	created: IsoAutoDateString;
 	description_espanol?: string;
 	description_rapa_nui?: string;
+	hist_chapter?: string;
+	hist_cycle?: LocationsHistCycleOptions;
 	id: string;
 	language?: LocationsLanguageOptions[];
 	latitude?: number;


### PR DESCRIPTION
## Summary

Adds a cycle selector for the Historias Perdidas layer so the map can show one ciclo at a time instead of all chapters at once.

## What Changed

- Adds a shared Historias Perdidas helper for layer detection and cycle labels.
- Adds sidebar state for Primer, Segundo, and Tercer Ciclo.
- Filters displayed map pins by the selected Historias cycle.
- Replaces the selected layer card image area with cycle choices while preserving the card structure and height.
- Updates PocketBase generated frontend types for the new `hist_cycle` and `hist_chapter` fields.
- Documents branch and commit conventions in `AGENTS.md`.

## Verification

- `npm run check` passes with existing Svelte warnings.
- `npm run lint` passes.
- `npm run build` passed earlier with existing warnings.

## Notes

This PR depends on the matching PocketBase PR that adds the `hist_cycle` and `hist_chapter` schema fields and seed script for the new chapter records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented cycle-based filtering for historias-perdidas locations with selector controls in map sidebars, enabling users to view locations categorized by primer, segundo, and tercer cycles.

* **Documentation**
  * Enhanced development guidelines with specific branch naming conventions and commit message format examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->